### PR TITLE
[UPDATE] 주문/장바구니 - 실제 회원id 사용

### DIFF
--- a/src/main/java/com/example/demo/controller/cart/CartController.java
+++ b/src/main/java/com/example/demo/controller/cart/CartController.java
@@ -1,12 +1,11 @@
 package com.example.demo.controller.cart;
 
-import com.example.demo.domain.cart.Cart;
-import com.example.demo.domain.cart.CartItem;
-import com.example.demo.domain.cart.dto.CartItemDto;
-import com.example.demo.service.cart.CartService;
-import jakarta.servlet.http.HttpSession;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +14,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.List;
+import com.example.demo.domain.cart.Cart;
+import com.example.demo.domain.cart.CartItem;
+import com.example.demo.domain.cart.dto.CartItemDto;
+import com.example.demo.service.cart.CartService;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Controller
@@ -27,27 +33,29 @@ public class CartController {
 	
 	// 상품상세에서 장바구니 담기 
 	@PostMapping
-	@ResponseBody
-	public String addCart(@RequestBody CartItemDto cartItemDto, HttpSession session) {
+	public ResponseEntity<String> addCart(@RequestBody CartItemDto cartItemDto, HttpSession session, Authentication authentication) {
+		// 회원 인증정보 확인
+		if(authentication == null || !authentication.isAuthenticated() ) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
 		
+		String memberId = authentication.getName();
 		// 회원id, 상품id, 구매개수, 가격 받아서 저장
-		String memberId = "user22";
 		cartService.makeOrderByCartItems(memberId, cartItemDto.getProductId(), cartItemDto.getQuantity(), cartItemDto.getPrice());
 		
-		// 알림 메시지에 들어갈 내용
-		return "상품을 장바구니에 담았습니다";
+		return ResponseEntity.status(HttpStatus.OK).body("상품을 담았습니다");
 	}
 
 	// 장바구니 불러오기
 	@GetMapping
-	public String getCart(Model model) {
+	@PreAuthorize("isAuthenticated()")
+	public String getCart(Model model, Authentication authentication) {
 
-		// 회원id 가져오기 - 테스트데이터
-		String memberId = "user22";
+		// 회원id 가져오기
+		String memberId = authentication.getName();
 
 		// 회원id로 장바구니 찾기
 		Cart memberCart = cartService.findCartByMemberId(memberId);
-		log.info("cart={}",memberCart);
 
 		// 장바구니에서 cartitem를 리스트로 가져오기
 		List<CartItem> cartItems = cartService.findAllItems(memberCart);
@@ -64,13 +72,12 @@ public class CartController {
 	// 장바구니 항목 삭제
 	@PostMapping("/delete")
 	@ResponseBody
-	public String deleteCartItem(@RequestBody CartItemDto cartItemDto) {
+	@PreAuthorize("isAuthenticated()")
+	public String deleteCartItem(@RequestBody CartItemDto cartItemDto, Authentication authentication) {
 		
-		log.info("cartItemDto DELETE IN CONTROLLER={}", cartItemDto);
 		Integer cartItemId = cartItemDto.getId();
 		
 		boolean isdeleted = cartService.deleteCartItem(cartItemDto);
-		log.info("isdeleted IN CONTROLLER={}",isdeleted);
 		
 		if (isdeleted) {
 			return "장바구니에서 상품을 삭제하였습니다";
@@ -82,6 +89,7 @@ public class CartController {
 	// 장바구니 항목 수량 업데이트
 	@PostMapping("/update")
 	@ResponseBody
+	@PreAuthorize("isAuthenticated()")
 	public String updateItemQuantity(@RequestBody CartItemDto cartItemDto) {
 		cartService.updateCartItemQuantity(cartItemDto);
 		

--- a/src/main/java/com/example/demo/service/cart/CartServiceImpl.java
+++ b/src/main/java/com/example/demo/service/cart/CartServiceImpl.java
@@ -26,14 +26,7 @@ public class CartServiceImpl implements CartService{
 	public int makeOrderByCartItems(String memberId, Integer productId, Integer quantity, Double price) {
 
 		// 회원id로 장바구니 조회
-		Cart cart = cartMapper.findByMemberId(memberId);
-
-		// 없으면 장바구니 생성
-		if (cart == null) {
-			cart = Cart.createCart(memberId);
-			cartMapper.saveCart(cart);
-		}
-
+		Cart cart = findCartByMemberId(memberId);
 		CartItem cartItem = cartMapper.findByCartIdAndProductId(cart.getId(), productId);
 
 		// 장바구니에 해당 cartitem이 없다면
@@ -55,9 +48,17 @@ public class CartServiceImpl implements CartService{
 		return 1;
 	}
 
+	// 회원id로 장바구니 가져오기
 	@Override
 	public Cart findCartByMemberId(String memberId) {
-		return cartMapper.findByMemberId(memberId);
+		Cart cart = cartMapper.findByMemberId(memberId);
+		
+		// 없으면 장바구니 생성
+		if (cart == null) {
+			cart = Cart.createCart(memberId);
+			cartMapper.saveCart(cart);
+		}
+		return cart;
 	}
 
 

--- a/src/main/webapp/js/product/product.js
+++ b/src/main/webapp/js/product/product.js
@@ -41,7 +41,13 @@ $("#orderButton").click(function() {
 			//값을 가지고
 			// orderdteatil/ odreid로 이동
 			//다른페이지로이동
+			// 상태코드 200
 			window.location.href = "/order/detail";
+		},
+		error: function(jqXHR, textStatus, errorThrown) {
+			// 상태코드 400, 401
+			// 로그인 이동
+			window.location.href = "/member/login";
 		}
 	});
 })
@@ -66,7 +72,11 @@ $("#goToCartBtn").click(function() {
 			//값을 가지고
 			// orderdteatil/ odreid로 이동
 			//다른페이지로이동
-			alert(message);
+			window.location.href="/cart";
+			alert(message); // alert말고 다른걸로 수정할 예정
+		},
+		error: function(jqXHR, textStatus, errorThrown) {
+			window.location.href = "/member/login";
 		}
 	});
 })


### PR DESCRIPTION
- 기존 코드에 작성된 테스트 회원id 제거
- 주문, 장바구니 로직에 @PreAuthorize("isAuthenticated()") 추가

- 주문, 장바구니 버튼 클릭과 관련된 메서드에는 @PreAuthorize 대신에 Authenticate로 직접 식별 후 ResponseEntity를 반환하도록 변경